### PR TITLE
use omit filter for username in tower_credential module.

### DIFF
--- a/tasks/config/organization/credential.yml
+++ b/tasks/config/organization/credential.yml
@@ -2,7 +2,7 @@
 - name: "config.organization.credential: Ensure state of credential: [ {{ tower_config_organization_credential.name }} ]"
   tower_credential:
     name: "{{ tower_config_organization_credential.name }}"
-    username: "{{ tower_config_organization_credential.username }}"
+    username: "{{ tower_config_organization_credential.username | default(omit) }}"
     password: "{{ tower_config_organization_credential.password | default(omit) }}"
     kind: "{{ tower_config_organization_credential.kind | default(omit) }}"
     organization: "{{ tower_config_organization.name | default(omit) }}"


### PR DESCRIPTION
credentials of type vault don't have username parameter