### PR TITLE
allow roles other than member

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,9 @@
   become: false
 
   vars:
+    # Required for: "victorock.tower_setup"
+    tower_setup_version: "3.5.4-1"
+    tower_setup_network_pips: []
     # Tower configuration
     tower_config:
       host: "localhost"

--- a/tasks/config/organization/user.yml
+++ b/tasks/config/organization/user.yml
@@ -21,9 +21,10 @@
     tower_host: "{{ tower_config.host }}"
     tower_username: "{{ tower_config.username }}"
     tower_password: "{{ tower_config.password }}"
+    tower_verify_ssl: "{{ tower_config.verify_ssl | default(omit) }}"
     user: "{{ tower_config_organization_user.name }}"
     organization: "{{ tower_config_organization.name }}"
-    role: "member"
+    role: "{{ tower_config_organization_user.role|default('member') }}"
     state: "present"
   async: 15
   poll: 1


### PR DESCRIPTION
This PR Adds the following capability:

- The use of `tower_verify_ssl` on the tower_role module.
- Assign other roles to org members such as admin, auditor etc

PR #14 removed tower_verify_ssl capability as it was causing an issue, I have not seen this issue arise. Perhaps it was caused by not having a default(omit) statement.

