### PR TITLE
wait for project to sync

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,9 @@
   become: false
 
   vars:
+    # Required for: "victorock.tower_setup"
+    tower_setup_version: "3.5.4-1"
+    tower_setup_network_pips: []
     # Tower configuration
     tower_config:
       host: "localhost"

--- a/tasks/config/organization/job_template.yml
+++ b/tasks/config/organization/job_template.yml
@@ -30,3 +30,7 @@
     state: "{{ tower_config_organization_job_template.state | default(omit) }}"
   async: 15
   poll: 1
+  register: job_template_result
+  retries: 20
+  delay: 5
+  until: job_template_result is success


### PR DESCRIPTION
When using this role without a large dictionary, sometimes when it reaches the task to configure a job template, the project hasn't finished syncing. This then causes the job_template task to fail.

This PR addresses this issue through the use of retry.