### PR TITLE
configure proxy task environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ tower_config:
       trial: XXXX
       eula_accepted: true
 
+    proxy:
+      http_proxy: "http://172.17.0.1:3128"
+      https_proxy: "http://172.17.0.1:3128"
+      no_proxy: "localhost,127.0.0.0/8"
+
   organization:
     README:
       name: "README"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,9 @@
   become: false
 
   vars:
+    # Required for: "victorock.tower_setup"
+    tower_setup_version: "3.5.4-1"
+    tower_setup_network_pips: []
     # Tower configuration
     tower_config:
       host: "localhost"

--- a/tasks/config/setting.yml
+++ b/tasks/config/setting.yml
@@ -2,3 +2,7 @@
 - name: "config.setting-cli: Process [ license ]"
   include_tasks: "setting/license.yml"
   when: tower_config.setting.license is defined
+
+- name: "config.setting-cli: Process [ proxy ]"
+  include_tasks: "setting/proxy.yml"
+  when: tower_config.setting.proxy is defined

--- a/tasks/config/setting/proxy.yml
+++ b/tasks/config/setting/proxy.yml
@@ -1,0 +1,21 @@
+---
+- name: "config.setting.proxy: Ensure state"
+  vars:
+    proxy_settings:
+      AWX_TASK_ENV:
+        http_proxy: "{{ tower_config.setting.proxy.http_proxy | default(omit) }}"
+        https_proxy: "{{ tower_config.setting.proxy.https_proxy | default(omit) }}"
+        no_proxy: "{{ tower_config.setting.proxy.no_proxy | default(omit) }}"
+  uri:
+    url: "https://{{ tower_config.host }}/api/v2/settings/all/"
+    user: "{{ tower_config.username }}"
+    password: "{{ tower_config.password }}"
+    validate_certs: "{{ tower_config.verify_ssl | default(omit) }}"
+    force_basic_auth: true
+    headers:
+      Content-Type: "application/json"
+      Accept: "application/json"
+    method: PATCH
+    body: "{{ proxy_settings }}"
+    body_format: "{{ tower_config.format }}"
+  register: reg_config_setting_proxy


### PR DESCRIPTION
This PR adds the capability to configure a proxy server using `AWX_TASK_ENV` in tower settings.
