### PR TITLE
feature: configure organisation virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ tower_config:
     README:
       name: "README"
       description: "README"
+      custom_virtualenv: "/path/to/virtualenv/readme" # or false, null, '', or unset to remove
       users:
         - name: "infraops"
           password: "infraops"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ tower_config:
     README:
       name: "README"
       description: "README"
-      custom_virtualenv: "/path/to/virtualenv/readme" # or false, null, '', or unset to remove
+      custom_virtualenv: "/path/to/virtualenv/readme" # Use false, null, '', or unset this variable to remove
       users:
         - name: "infraops"
           password: "infraops"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,9 @@
   become: false
 
   vars:
+    # Required for: "victorock.tower_setup"
+    tower_setup_version: "3.5.4-1"
+    tower_setup_network_pips: []
     # Tower configuration
     tower_config:
       host: "localhost"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -26,6 +26,7 @@
         README:
           name: "Default"
           description: "Default"
+          custom_virtualenv: "/var/lib/awx/venv/ansible-cloud-release"
           users:
             - name: "infraops"
               password: "infraops"

--- a/tasks/config/organization/custom_virtualenv.yml
+++ b/tasks/config/organization/custom_virtualenv.yml
@@ -1,0 +1,4 @@
+---
+- name: "config.organization.custom_virtualenv: [ {{ tower_config_organization.custom_virtualenv }} ]"
+  command: "{{ lookup('template', 'custom-virtualenv-cli.j2') }}"
+  register: reg_custom_virtualenv

--- a/tasks/config/organization/custom_virtualenv.yml
+++ b/tasks/config/organization/custom_virtualenv.yml
@@ -2,3 +2,4 @@
 - name: "config.organization.custom_virtualenv: [ {{ tower_config_organization.custom_virtualenv }} ]"
   command: "{{ lookup('template', 'custom-virtualenv-cli.j2') }}"
   register: reg_custom_virtualenv
+  when: tower_config_organization.custom_virtualenv is defined

--- a/tasks/config/organization/main.yml
+++ b/tasks/config/organization/main.yml
@@ -9,6 +9,10 @@
     description: "{{ tower_config_organization.description | default(omit) }}"
     state: "{{ tower_config_organization.state | default('present') }}"
 
+- name: "config.organization: Process [ custom_virtualenv ]"
+  include_tasks: "custom_virtualenv.yml"
+  when: tower_config_organization.custom_virtualenv is defined
+
 - name: "config.organization: Process [ users ]"
   when: tower_config_organization.users is defined
   include_tasks: "user.yml"

--- a/templates/custom-virtualenv-cli.j2
+++ b/templates/custom-virtualenv-cli.j2
@@ -1,0 +1,7 @@
+tower-cli
+organization
+modify
+--custom-virtualenv {{ tower_config_organization.custom_virtualenv | default('null') }}
+{% if tower_config_organization.name is defined %}
+--name {{ tower_config_organization.name | quote }}
+{% endif %}


### PR DESCRIPTION
This PR adds the parameter `custom_virtualenv` to the organisation dictionary. This allows you to assign by default a custom virtual environment to the desired organisation.

Added in a test, let me know if you want to keep it or remove it.