### PR TITLE
Add more inventory source options

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,9 @@
   become: false
 
   vars:
+    # Required for: "victorock.tower_setup"
+    tower_setup_version: "3.5.4-1"
+    tower_setup_network_pips: []
     # Tower configuration
     tower_config:
       host: "localhost"

--- a/tasks/config/organization/inventory/source.yml
+++ b/tasks/config/organization/inventory/source.yml
@@ -21,6 +21,7 @@
     source_script: "{{ tower_config_organization_inventory_source.source_script | default(omit) }}"
     source_vars: "{{ tower_config_organization_inventory_source.source_vars | default(omit) }}"
     update_on_launch: "{{ tower_config_organization_inventory_source.update_on_launch | default(omit) }}"
-    update_on_project_update: "{{ tower_config_organization_inventory_source.update_on_project_update | default(omit) }}"
+    update_on_project_update: "{{ tower_config_organization_inventory_source.update_on_project_update
+                              | default(omit) }}"
   async: 15
   poll: 1

--- a/tasks/config/organization/inventory/source.yml
+++ b/tasks/config/organization/inventory/source.yml
@@ -20,5 +20,7 @@
     source_regions: "{{ tower_config_organization_inventory_source.source_regions | default(omit) }}"
     source_script: "{{ tower_config_organization_inventory_source.source_script | default(omit) }}"
     source_vars: "{{ tower_config_organization_inventory_source.source_vars | default(omit) }}"
+    update_on_launch: "{{ tower_config_organization_inventory_source.update_on_launch | default(omit) }}"
+    update_on_project_update: "{{ tower_config_organization_inventory_source.update_on_project_update | default(omit) }}"
   async: 15
   poll: 1


### PR DESCRIPTION
This PR add the options `update_on_launch` and `update_on_project_update` to the `tower_inventory_source` module/task. 