### PR TITLE
Fix license api version for tower 3.6.x

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -4,6 +4,9 @@
   become: false
 
   vars:
+    # Required for: "victorock.tower_setup"
+    tower_setup_version: "3.5.4-1"
+    tower_setup_network_pips: []
     # Tower configuration
     tower_config:
       host: "localhost"

--- a/tasks/config/setting/license.yml
+++ b/tasks/config/setting/license.yml
@@ -1,7 +1,7 @@
 ---
 - name: "config.setting.license: Ensure state"
   uri:
-    url: "https://{{ tower_config.host }}/api/v1/config/"
+    url: "https://{{ tower_config.host }}/api/v2/config/"
     user: "{{ tower_config.username }}"
     password: "{{ tower_config.password }}"
     validate_certs: "{{ tower_config.verify_ssl | default(omit) }}"


### PR DESCRIPTION
In Ansible Tower 3.6.x v2 of the Tower API is deprecated. This PR fixes the license task so that it used v2.